### PR TITLE
simplify drag math

### DIFF
--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -62,7 +62,6 @@ export const Draggable: React.FC<DraggableProps> = ({
       initialXPosition,
       gapSize,
       gridIndicatorSize,
-      initialXPosition,
       gridSize.width,
       width,
     ),
@@ -70,7 +69,6 @@ export const Draggable: React.FC<DraggableProps> = ({
       initialYPosition,
       gapSize,
       gridIndicatorSize,
-      initialYPosition,
       gridSize.height,
       height,
     ),
@@ -112,11 +110,10 @@ export const Draggable: React.FC<DraggableProps> = ({
         pointerX,
         gapSize,
         gridIndicatorSize,
-        position.x,
         gridSize.width,
         width,
       ),
-    [gapSize, gridIndicatorSize, gridSize.width, position.x, width],
+    [gapSize, gridIndicatorSize, gridSize.width, width],
   );
 
   const getClosestValidYPosition = React.useCallback(
@@ -125,11 +122,10 @@ export const Draggable: React.FC<DraggableProps> = ({
         pointerY,
         gapSize,
         gridIndicatorSize,
-        position.y,
         gridSize.height,
         height,
       ),
-    [gapSize, gridIndicatorSize, gridSize.height, height, position.y],
+    [gapSize, gridIndicatorSize, gridSize.height, position.y],
   );
   const stopDrag = React.useCallback(() => {
     if (!isDragging || !pointerStartPosition) {

--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -125,7 +125,7 @@ export const Draggable: React.FC<DraggableProps> = ({
         gridSize.height,
         height,
       ),
-    [gapSize, gridIndicatorSize, gridSize.height, position.y],
+    [gapSize, gridIndicatorSize, gridSize.height, height position.y],
   );
   const stopDrag = React.useCallback(() => {
     if (!isDragging || !pointerStartPosition) {

--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -125,7 +125,7 @@ export const Draggable: React.FC<DraggableProps> = ({
         gridSize.height,
         height,
       ),
-    [gapSize, gridIndicatorSize, gridSize.height, height position.y],
+    [gapSize, gridIndicatorSize, gridSize.height, height, position.y],
   );
   const stopDrag = React.useCallback(() => {
     if (!isDragging || !pointerStartPosition) {

--- a/src/utils/draggable.utils.test.ts
+++ b/src/utils/draggable.utils.test.ts
@@ -153,7 +153,6 @@ describe("draggable utils", () => {
             attemptedXPosition,
             gapSize,
             gridIndicatorSize,
-            attemptedXPosition,
             gridWidth,
             width,
           );
@@ -170,7 +169,6 @@ describe("draggable utils", () => {
         attemptedXPosition,
         gapSize,
         gridIndicatorSize,
-        attemptedXPosition,
         gridWidth,
         width,
       );
@@ -186,7 +184,6 @@ describe("draggable utils", () => {
         attemptedXPosition,
         gapSize,
         gridIndicatorSize,
-        attemptedXPosition,
         gridWidth,
         width,
       );
@@ -202,7 +199,6 @@ describe("draggable utils", () => {
         attemptedXPosition,
         gapSize,
         gridIndicatorSize,
-        attemptedXPosition,
         gridWidth,
         width,
       );
@@ -218,7 +214,6 @@ describe("draggable utils", () => {
         attemptedXPosition,
         gapSize,
         gridIndicatorSize,
-        attemptedXPosition,
         gridWidth,
         width,
       );

--- a/src/utils/draggable.utils.ts
+++ b/src/utils/draggable.utils.ts
@@ -23,10 +23,9 @@ export const calculateClosestValidSizeComponent = (
 };
 
 export const calculateClosestValidPositionComponent = (
-  pointerPos: number,
+  position: number,
   gapSize: number,
   gridIndicatorSize: number,
-  position: number,
   gridSizeComponent: number,
   elementSizeComponent: number,
 ): number => {
@@ -36,8 +35,8 @@ export const calculateClosestValidPositionComponent = (
   const closestInPositiveDirection = Math.ceil(position / stepSize) * stepSize;
 
   const negativeIsClosest =
-    Math.abs(pointerPos - closestInNegativeDirection) <
-    Math.abs(pointerPos - closestInPositiveDirection);
+    Math.abs(position - closestInNegativeDirection) <
+    Math.abs(position - closestInPositiveDirection);
 
   const closestValue = negativeIsClosest
     ? closestInNegativeDirection


### PR DESCRIPTION
`calculateClosestValidPositionComponent` had two equal parameters. Let's
remove one of them.