### PR TITLE
Show selected Draggable on top

### DIFF
--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -334,7 +334,7 @@ export const Draggable: React.FC<DraggableProps> = ({
         transform: `translateX(${position.x}px) translateY(${position.y}px)`,
         width: width + offset,
         height: height + offset,
-        zIndex: isDragging ? 2 : undefined,
+        zIndex: isDragging || (selectedItem === id) ? 2 : undefined,
         pointerEvents: isPreview || isResizing ? "none" : undefined,
       }}
       aria-label={labelText}


### PR DESCRIPTION
Will make sure that the context menu is visible for the selected box.