### PR TITLE
improve CSS Modules typings

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,2 +1,9 @@
-declare module "*.module.css";
-declare module "*.module.scss";
+declare module "*.module.css" {
+  const styles: { [className: string]: string};
+  export default styles;
+}
+
+declare module "*.module.scss" {
+  const styles: { [className: string]: string};
+  export default styles;
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -1,9 +1,9 @@
 declare module "*.module.css" {
-  const styles: { [className: string]: string};
+  const styles: { [className: string]: string };
   export default styles;
 }
 
 declare module "*.module.scss" {
-  const styles: { [className: string]: string};
+  const styles: { [className: string]: string };
   export default styles;
 }


### PR DESCRIPTION
Previously, imported classes were typed as `any`. They are now `string`s.