### PR TITLE
rename `gridIndicatorSize` to `cellSize`

### DIFF
--- a/src/components/Draggable/Draggable.stories.tsx
+++ b/src/components/Draggable/Draggable.stories.tsx
@@ -13,7 +13,7 @@ export default {
     height: 100,
     width: 100,
     gapSize: 10,
-    gridIndicatorSize: 10,
+    cellSize: 10,
     gridSize: {
       width: 200,
       height: 100,

--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -28,7 +28,7 @@ export type DraggableProps = {
   initialWidth: number;
   initialHeight: number;
   gapSize: number;
-  gridIndicatorSize: number;
+  cellSize: number;
   gridSize: Size;
   occupiedCells: Array<OccupiedCell>;
   isPreview: boolean;
@@ -61,7 +61,7 @@ export const Draggable: React.FC<DraggableProps> = ({
   initialWidth,
   initialHeight,
   gapSize,
-  gridIndicatorSize,
+  cellSize,
   gridSize,
   occupiedCells,
   isPreview,
@@ -83,15 +83,15 @@ export const Draggable: React.FC<DraggableProps> = ({
     React.useState<Position | null>();
   const [{ width, height }, setSize] = React.useState<Size>({
     // prettier-ignore
-    width: calculateClosestValidSizeComponent(initialWidth, gapSize, gridIndicatorSize, gridSize.width),
+    width: calculateClosestValidSizeComponent(initialWidth, gapSize, cellSize, gridSize.width),
     // prettier-ignore
-    height: calculateClosestValidSizeComponent(initialHeight, gapSize, gridIndicatorSize, gridSize.height),
+    height: calculateClosestValidSizeComponent(initialHeight, gapSize, cellSize, gridSize.height),
   });
   const [position, setPosition] = React.useState<Position>({
     // prettier-ignore
-    x: calculateClosestValidPositionComponent(initialXPosition, gapSize, gridIndicatorSize, gridSize.width, width),
+    x: calculateClosestValidPositionComponent(initialXPosition, gapSize, cellSize, gridSize.width, width),
     // prettier-ignore
-    y: calculateClosestValidPositionComponent(initialYPosition, gapSize, gridIndicatorSize, gridSize.height, height),
+    y: calculateClosestValidPositionComponent(initialYPosition, gapSize, cellSize, gridSize.height, height),
   });
   const [previousPosition, setPreviousPosition] =
     React.useState<Position>(position);
@@ -104,13 +104,13 @@ export const Draggable: React.FC<DraggableProps> = ({
     () =>
       setSize({
         // prettier-ignore
-        width: calculateClosestValidSizeComponent(initialWidth, gapSize, gridIndicatorSize, gridSize.width),
+        width: calculateClosestValidSizeComponent(initialWidth, gapSize, cellSize, gridSize.width),
         // prettier-ignore
-        height: calculateClosestValidSizeComponent(initialHeight, gapSize, gridIndicatorSize, gridSize.height),
+        height: calculateClosestValidSizeComponent(initialHeight, gapSize, cellSize, gridSize.height),
       }),
     [
       gapSize,
-      gridIndicatorSize,
+      cellSize,
       gridSize.height,
       gridSize.width,
       initialHeight,
@@ -122,13 +122,13 @@ export const Draggable: React.FC<DraggableProps> = ({
   React.useEffect(() => {
     setPosition({
       // prettier-ignore
-      x: calculateClosestValidPositionComponent(initialXPosition, gapSize, gridIndicatorSize, gridSize.width, width),
+      x: calculateClosestValidPositionComponent(initialXPosition, gapSize, cellSize, gridSize.width, width),
       // prettier-ignore
-      y: calculateClosestValidPositionComponent(initialYPosition, gapSize, gridIndicatorSize, gridSize.height, height),
+      y: calculateClosestValidPositionComponent(initialYPosition, gapSize, cellSize, gridSize.height, height),
     });
   }, [
     gapSize,
-    gridIndicatorSize,
+    cellSize,
     gridSize.height,
     gridSize.width,
     height,
@@ -165,11 +165,11 @@ export const Draggable: React.FC<DraggableProps> = ({
       calculateClosestValidPositionComponent(
         pointerX,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridSize.width,
         width,
       ),
-    [gapSize, gridIndicatorSize, gridSize.width, width],
+    [gapSize, cellSize, gridSize.width, width],
   );
 
   const getClosestValidYPosition = React.useCallback(
@@ -177,11 +177,11 @@ export const Draggable: React.FC<DraggableProps> = ({
       calculateClosestValidPositionComponent(
         pointerY,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridSize.height,
         height,
       ),
-    [gapSize, gridIndicatorSize, gridSize.height, height],
+    [gapSize, cellSize, gridSize.height, height],
   );
 
   const checkIfPositionIsFree = React.useCallback(
@@ -192,11 +192,11 @@ export const Draggable: React.FC<DraggableProps> = ({
         { width, height },
         gridSize,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         occupiedCells,
       );
     },
-    [gapSize, gridIndicatorSize, gridSize, height, id, occupiedCells, width],
+    [gapSize, cellSize, gridSize, height, id, occupiedCells, width],
   );
 
   const stopDrag = React.useCallback(() => {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -100,7 +100,7 @@ export const Grid: React.FC<GridProps> = ({
     setSelectedItem(newItem);
   }, []);
 
-  const getGridIndicatorSize = React.useCallback(() => {
+  const getCellSize = React.useCallback(() => {
     if (!elementRef.current) {
       return 0;
     }
@@ -128,9 +128,9 @@ export const Grid: React.FC<GridProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [size]);
 
-  const gridIndicatorSize = React.useMemo(getGridIndicatorSize, [
+  const cellSize = React.useMemo(getCellSize, [
     gapSize,
-    getGridIndicatorSize,
+    getCellSize,
     elementRef.current,
   ]);
 
@@ -153,11 +153,11 @@ export const Grid: React.FC<GridProps> = ({
           size.width,
           size.height,
           gapSize,
-          gridIndicatorSize,
+          cellSize,
         ),
       );
     },
-    [gapSize, gridIndicatorSize, items, size, updateItems],
+    [gapSize, cellSize, items, size, updateItems],
   );
 
   const createArrowEnter = React.useCallback(
@@ -254,7 +254,7 @@ export const Grid: React.FC<GridProps> = ({
         newSize,
         size,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         occupiedCells,
       );
 
@@ -271,7 +271,7 @@ export const Grid: React.FC<GridProps> = ({
       arrowStartIndex,
       currentArrowItemsLength,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
       isDragging,
       numberOfColumns,
       numberOfRows,
@@ -417,7 +417,7 @@ export const Grid: React.FC<GridProps> = ({
         newSize,
         size,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         occupiedCells,
       );
 
@@ -455,7 +455,7 @@ export const Grid: React.FC<GridProps> = ({
       currentItemsLength,
       items,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
       occupiedCells,
       updateItems,
       updateItemSize,
@@ -563,7 +563,7 @@ export const Grid: React.FC<GridProps> = ({
         newSize,
         size,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         occupiedCells,
       );
 
@@ -592,7 +592,7 @@ export const Grid: React.FC<GridProps> = ({
       numberOfRows,
       items,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
       occupiedCells,
       updateItems,
       resizeDirectionLock,
@@ -698,12 +698,12 @@ export const Grid: React.FC<GridProps> = ({
         size.width,
         size.height,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
       );
 
       setOccupiedCells(newOccupiedCells);
     },
-    [gapSize, gridIndicatorSize, items, size, updateItems],
+    [gapSize, cellSize, items, size, updateItems],
   );
 
   const updateArrowPosition = React.useCallback(
@@ -781,7 +781,7 @@ export const Grid: React.FC<GridProps> = ({
   );
 
   const children = React.useMemo(() => {
-    if (gapSize == null || gridIndicatorSize == null || size == null) {
+    if (gapSize == null || cellSize == null || size == null) {
       return null;
     }
 
@@ -795,7 +795,7 @@ export const Grid: React.FC<GridProps> = ({
         initialWidth={Math.abs(scaleX(item.widthPercentage, size.width))}
         initialHeight={Math.abs(scaleY(item.heightPercentage, size.height))}
         gapSize={gapSize}
-        gridIndicatorSize={gridIndicatorSize}
+        cellSize={cellSize}
         gridSize={size}
         occupiedCells={occupiedCells}
         isPreview={isDragging}
@@ -823,7 +823,7 @@ export const Grid: React.FC<GridProps> = ({
     ));
   }, [
     gapSize,
-    gridIndicatorSize,
+    cellSize,
     size,
     items,
     occupiedCells,
@@ -839,7 +839,7 @@ export const Grid: React.FC<GridProps> = ({
   ]);
 
   const childrenArrows = React.useMemo(() => {
-    if (gapSize == null || gridIndicatorSize == null || size == null) {
+    if (gapSize == null || cellSize == null || size == null) {
       return null;
     }
 
@@ -864,7 +864,7 @@ export const Grid: React.FC<GridProps> = ({
           initialWidth={Math.abs(scaleX(item.widthPercentage, size.width))}
           initialHeight={Math.abs(scaleY(item.heightPercentage, size.height))}
           gapSize={gapSize}
-          gridIndicatorSize={gridIndicatorSize}
+          cellSize={cellSize}
           gridSize={size}
           occupiedCells={occupiedCells}
           isPreview={isDragging}
@@ -899,7 +899,7 @@ export const Grid: React.FC<GridProps> = ({
     });
   }, [
     gapSize,
-    gridIndicatorSize,
+    cellSize,
     size,
     arrowItems,
     numberOfColumns,
@@ -967,7 +967,7 @@ export const Grid: React.FC<GridProps> = ({
     resize();
 
     // The grid's number of rows/columns might be updated by external factors,
-    // but still affects the grid indicator size
+    // but still affects the cell size
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [numberOfColumns, numberOfRows]);
 
@@ -982,10 +982,10 @@ export const Grid: React.FC<GridProps> = ({
         size.width,
         size.height,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
       ),
     );
-  }, [gapSize, gridIndicatorSize, items, size]);
+  }, [gapSize, cellSize, items, size]);
 
   return (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions

--- a/src/utils/draggable.utils.test.ts
+++ b/src/utils/draggable.utils.test.ts
@@ -12,7 +12,7 @@ describe("draggable utils", () => {
       10, 25, 40, and 55.
 
       The grid looks like this:
-      ([ ] = grid indicator)
+      ([ ] = cell)
 
       [ ] [ ] [ ] [ ]
       [ ] [ ] [ ] [ ]
@@ -23,7 +23,7 @@ describe("draggable utils", () => {
     const validWidths: ReadonlyArray<number> = [10, 25, 40, 55];
 
     const gapSize = 5;
-    const gridIndicatorSize = 10;
+    const cellSize = 10;
     const gridWidth = 55;
 
     it("should handle any number value", () =>
@@ -32,7 +32,7 @@ describe("draggable utils", () => {
           const newWidth = calculateClosestValidSizeComponent(
             attemptedWidth,
             gapSize,
-            gridIndicatorSize,
+            cellSize,
             gridWidth,
           );
 
@@ -47,7 +47,7 @@ describe("draggable utils", () => {
       const actualWidth = calculateClosestValidSizeComponent(
         width,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
       );
 
@@ -61,7 +61,7 @@ describe("draggable utils", () => {
       const actualWidth = calculateClosestValidSizeComponent(
         width,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
       );
 
@@ -75,7 +75,7 @@ describe("draggable utils", () => {
       const actualWidth = calculateClosestValidSizeComponent(
         width,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
       );
 
@@ -89,7 +89,7 @@ describe("draggable utils", () => {
       const actualWidth = calculateClosestValidSizeComponent(
         width,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
       );
 
@@ -103,7 +103,7 @@ describe("draggable utils", () => {
       const actualWidth = calculateClosestValidSizeComponent(
         width,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
       );
 
@@ -116,7 +116,7 @@ describe("draggable utils", () => {
       const actualWidth = calculateClosestValidSizeComponent(
         width,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
       );
 
@@ -128,10 +128,10 @@ describe("draggable utils", () => {
     /*
       With these values, valid x positions are
       0, 15, 30, and 45 if the element is exactly
-      one gridIndicatorSize wide (1).
+      one cellSize wide (1).
 
       The grid looks like this:
-      ([ ] = grid indicator)
+      ([ ] = cell)
 
       [ ] [ ] [ ] [ ]
       [ ] [ ] [ ] [ ]
@@ -142,8 +142,8 @@ describe("draggable utils", () => {
     const validXPositions: ReadonlyArray<number> = [0, 15, 30, 45];
 
     const gapSize = 5;
-    const gridIndicatorSize = 10;
-    const width = gridIndicatorSize;
+    const cellSize = 10;
+    const width = cellSize;
     const gridWidth = 55;
 
     it("should handle all number values", () =>
@@ -152,7 +152,7 @@ describe("draggable utils", () => {
           const xPosition = calculateClosestValidPositionComponent(
             attemptedXPosition,
             gapSize,
-            gridIndicatorSize,
+            cellSize,
             gridWidth,
             width,
           );
@@ -168,7 +168,7 @@ describe("draggable utils", () => {
       const actualXPos = calculateClosestValidPositionComponent(
         attemptedXPosition,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
         width,
       );
@@ -183,7 +183,7 @@ describe("draggable utils", () => {
       const actualXPos = calculateClosestValidPositionComponent(
         attemptedXPosition,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
         width,
       );
@@ -198,7 +198,7 @@ describe("draggable utils", () => {
       const actualXPos = calculateClosestValidPositionComponent(
         attemptedXPosition,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
         width,
       );
@@ -213,7 +213,7 @@ describe("draggable utils", () => {
       const actualXPos = calculateClosestValidPositionComponent(
         attemptedXPosition,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
         gridWidth,
         width,
       );

--- a/src/utils/draggable.utils.ts
+++ b/src/utils/draggable.utils.ts
@@ -6,10 +6,10 @@ import { clamp } from "./number.utils";
 export const calculateClosestValidSizeComponent = (
   attemptedSize: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
   gridSize: number,
 ): number => {
-  const stepSize = gridIndicatorSize + gapSize;
+  const stepSize = cellSize + gapSize;
   const stepNumber = attemptedSize / stepSize;
 
   const smallerWidth = Math.floor(stepNumber) * stepSize - gapSize;
@@ -19,7 +19,7 @@ export const calculateClosestValidSizeComponent = (
     attemptedSize - smallerWidth < largerWidth - attemptedSize;
   const closestValidWidth = smallerIsClosest ? smallerWidth : largerWidth;
 
-  const minimum = gridIndicatorSize;
+  const minimum = cellSize;
   const maximum = gridSize;
 
   return clamp(minimum, closestValidWidth, maximum);
@@ -28,11 +28,11 @@ export const calculateClosestValidSizeComponent = (
 export const calculateClosestValidPositionComponent = (
   position: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
   gridSizeComponent: number,
   elementSizeComponent: number,
 ): number => {
-  const stepSize = gridIndicatorSize + gapSize;
+  const stepSize = cellSize + gapSize;
 
   const closestInNegativeDirection = Math.floor(position / stepSize) * stepSize;
   const closestInPositiveDirection = Math.ceil(position / stepSize) * stepSize;

--- a/src/utils/grid.utils.test.ts
+++ b/src/utils/grid.utils.test.ts
@@ -436,7 +436,7 @@ describe(updateItem.name, () => {
 describe(findCellsElementOccupies.name, () => {
   /*
     The grid looks like this:
-    ([ ] = grid indicator)
+    ([ ] = cell)
 
     [ ] [ ] [ ] [ ]
     [ ] [ ] [ ] [ ]
@@ -445,7 +445,7 @@ describe(findCellsElementOccupies.name, () => {
   */
 
   const gapSize = 5;
-  const gridIndicatorSize = 10;
+  const cellSize = 10;
   const gridWidth = 55;
   const gridHeight = 55;
 
@@ -472,7 +472,7 @@ describe(findCellsElementOccupies.name, () => {
       gridWidth,
       gridHeight,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
     );
 
     expect(actualCells).toEqual(expectedCells);
@@ -522,7 +522,7 @@ describe(findCellsElementOccupies.name, () => {
       gridWidth,
       gridHeight,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
     );
 
     expect(actualCells).toEqual(expectedCells);
@@ -558,7 +558,7 @@ describe(findCellsElementOccupies.name, () => {
       gridWidth,
       gridHeight,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
     );
 
     expect(actualCells).toEqual(expectedCells);
@@ -569,13 +569,13 @@ describe(getAllCells.name, () => {
   it("should return exactly as many cells as there should be", () => {
     /*
       The grid looks like this:
-      ([ ] = grid indicator)
+      ([ ] = cell)
 
       [ ] [ ]
       [ ] [ ]
     */
     const gapSize = 5;
-    const gridIndicatorSize = 10;
+    const cellSize = 10;
     const gridWidth = 25;
     const gridHeight = 25;
 
@@ -585,12 +585,7 @@ describe(getAllCells.name, () => {
       { x: 0, y: 15, index: 2 },
       { x: 15, y: 15, index: 3 },
     ];
-    const actualCells = getAllCells(
-      gridWidth,
-      gridHeight,
-      gapSize,
-      gridIndicatorSize,
-    );
+    const actualCells = getAllCells(gridWidth, gridHeight, gapSize, cellSize);
 
     expect(actualCells).toEqual(expectedCells);
   });
@@ -601,7 +596,7 @@ describe(cellIsOccupiedByElement.name, () => {
       We have placed an element in (1, 1) with the dimensions w: 3, h: 3.
 
       The grid looks like this:
-      ([ ] = grid indicator)
+      ([ ] = cell)
       ([x] = our 3*3 element)
 
       [ ] [ ] [ ] [ ] [ ]
@@ -612,15 +607,15 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
   const gapSize = 5;
-  const gridIndicatorSize = 10;
+  const cellSize = 10;
 
   const elementPosition: Position = {
-    x: 1 * gapSize + 1 * gridIndicatorSize,
-    y: 1 * gapSize + 1 * gridIndicatorSize,
+    x: 1 * gapSize + 1 * cellSize,
+    y: 1 * gapSize + 1 * cellSize,
   };
   const elementSize: Size = {
-    width: 2 * gapSize + 3 * gridIndicatorSize,
-    height: 2 * gapSize + 3 * gridIndicatorSize,
+    width: 2 * gapSize + 3 * cellSize,
+    height: 2 * gapSize + 3 * cellSize,
   };
 
   it("should return true if the cell is in the top left corner of the element", () => {
@@ -635,8 +630,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 1 * gapSize + 1 * gridIndicatorSize,
-      y: 1 * gapSize + 1 * gridIndicatorSize,
+      x: 1 * gapSize + 1 * cellSize,
+      y: 1 * gapSize + 1 * cellSize,
     };
 
     const expected = true;
@@ -661,8 +656,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 2 * gapSize + 2 * gridIndicatorSize,
-      y: 1 * gapSize + 1 * gridIndicatorSize,
+      x: 2 * gapSize + 2 * cellSize,
+      y: 1 * gapSize + 1 * cellSize,
     };
 
     const expected = true;
@@ -687,8 +682,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 3 * gapSize + 3 * gridIndicatorSize,
-      y: 1 * gapSize + 1 * gridIndicatorSize,
+      x: 3 * gapSize + 3 * cellSize,
+      y: 1 * gapSize + 1 * cellSize,
     };
 
     const expected = true;
@@ -713,8 +708,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 3 * gapSize + 3 * gridIndicatorSize,
-      y: 2 * gapSize + 2 * gridIndicatorSize,
+      x: 3 * gapSize + 3 * cellSize,
+      y: 2 * gapSize + 2 * cellSize,
     };
 
     const expected = true;
@@ -739,8 +734,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 3 * gapSize + 3 * gridIndicatorSize,
-      y: 3 * gapSize + 3 * gridIndicatorSize,
+      x: 3 * gapSize + 3 * cellSize,
+      y: 3 * gapSize + 3 * cellSize,
     };
 
     const expected = true;
@@ -765,8 +760,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 2 * gapSize + 2 * gridIndicatorSize,
-      y: 3 * gapSize + 3 * gridIndicatorSize,
+      x: 2 * gapSize + 2 * cellSize,
+      y: 3 * gapSize + 3 * cellSize,
     };
 
     const expected = true;
@@ -791,8 +786,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 1 * gapSize + 1 * gridIndicatorSize,
-      y: 3 * gapSize + 3 * gridIndicatorSize,
+      x: 1 * gapSize + 1 * cellSize,
+      y: 3 * gapSize + 3 * cellSize,
     };
 
     const expected = true;
@@ -817,8 +812,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 1 * gapSize + 1 * gridIndicatorSize,
-      y: 2 * gapSize + 2 * gridIndicatorSize,
+      x: 1 * gapSize + 1 * cellSize,
+      y: 2 * gapSize + 2 * cellSize,
     };
 
     const expected = true;
@@ -843,8 +838,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 2 * gapSize + 2 * gridIndicatorSize,
-      y: 2 * gapSize + 2 * gridIndicatorSize,
+      x: 2 * gapSize + 2 * cellSize,
+      y: 2 * gapSize + 2 * cellSize,
     };
 
     const expected = true;
@@ -869,8 +864,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 2 * gapSize + 2 * gridIndicatorSize,
-      y: 0 * gapSize + 0 * gridIndicatorSize,
+      x: 2 * gapSize + 2 * cellSize,
+      y: 0 * gapSize + 0 * cellSize,
     };
 
     const expected = false;
@@ -895,8 +890,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 4 * gapSize + 4 * gridIndicatorSize,
-      y: 2 * gapSize + 2 * gridIndicatorSize,
+      x: 4 * gapSize + 4 * cellSize,
+      y: 2 * gapSize + 2 * cellSize,
     };
 
     const expected = false;
@@ -921,8 +916,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 4 * gapSize + 4 * gridIndicatorSize,
-      y: 2 * gapSize + 2 * gridIndicatorSize,
+      x: 4 * gapSize + 4 * cellSize,
+      y: 2 * gapSize + 2 * cellSize,
     };
 
     const expected = false;
@@ -947,8 +942,8 @@ describe(cellIsOccupiedByElement.name, () => {
     */
 
     const cellPosition: Position = {
-      x: 0 * gapSize + 0 * gridIndicatorSize,
-      y: 2 * gapSize + 2 * gridIndicatorSize,
+      x: 0 * gapSize + 0 * cellSize,
+      y: 2 * gapSize + 2 * cellSize,
     };
 
     const expected = false;
@@ -967,7 +962,7 @@ describe(positionIsFree.name, () => {
     We have placed an element in (2, 1) with the dimensions w: 2, h: 3.
 
     The grid looks like this:
-    ([ ] = grid indicator)
+    ([ ] = cell)
     ([x] = our 2*3 element)
 
         0  15  30  45
@@ -978,50 +973,50 @@ describe(positionIsFree.name, () => {
   */
 
   const gapSize = 5;
-  const gridIndicatorSize = 10;
+  const cellSize = 10;
 
   const occupiedCells: Array<OccupiedCell> = [
     {
       index: 6,
       occupiedById: "1",
       occupiedByType: "item",
-      x: coordinatePosToPx(2, gapSize, gridIndicatorSize),
-      y: coordinatePosToPx(1, gapSize, gridIndicatorSize),
+      x: coordinatePosToPx(2, gapSize, cellSize),
+      y: coordinatePosToPx(1, gapSize, cellSize),
     },
     {
       index: 7,
       occupiedById: "1",
       occupiedByType: "item",
-      x: coordinatePosToPx(3, gapSize, gridIndicatorSize),
-      y: coordinatePosToPx(1, gapSize, gridIndicatorSize),
+      x: coordinatePosToPx(3, gapSize, cellSize),
+      y: coordinatePosToPx(1, gapSize, cellSize),
     },
     {
       index: 10,
       occupiedById: "1",
       occupiedByType: "item",
-      x: coordinatePosToPx(2, gapSize, gridIndicatorSize),
-      y: coordinatePosToPx(2, gapSize, gridIndicatorSize),
+      x: coordinatePosToPx(2, gapSize, cellSize),
+      y: coordinatePosToPx(2, gapSize, cellSize),
     },
     {
       index: 11,
       occupiedById: "1",
       occupiedByType: "item",
-      x: coordinatePosToPx(3, gapSize, gridIndicatorSize),
-      y: coordinatePosToPx(2, gapSize, gridIndicatorSize),
+      x: coordinatePosToPx(3, gapSize, cellSize),
+      y: coordinatePosToPx(2, gapSize, cellSize),
     },
     {
       index: 14,
       occupiedById: "1",
       occupiedByType: "item",
-      x: coordinatePosToPx(2, gapSize, gridIndicatorSize),
-      y: coordinatePosToPx(3, gapSize, gridIndicatorSize),
+      x: coordinatePosToPx(2, gapSize, cellSize),
+      y: coordinatePosToPx(3, gapSize, cellSize),
     },
     {
       index: 15,
       occupiedById: "1",
       occupiedByType: "item",
-      x: coordinatePosToPx(3, gapSize, gridIndicatorSize),
-      y: coordinatePosToPx(3, gapSize, gridIndicatorSize),
+      x: coordinatePosToPx(3, gapSize, cellSize),
+      y: coordinatePosToPx(3, gapSize, cellSize),
     },
   ];
 
@@ -1048,7 +1043,7 @@ describe(positionIsFree.name, () => {
       elementSize,
       gridSize,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
       occupiedCells,
     );
 
@@ -1075,7 +1070,7 @@ describe(positionIsFree.name, () => {
       elementSize,
       gridSize,
       gapSize,
-      gridIndicatorSize,
+      cellSize,
       occupiedCells,
     );
 

--- a/src/utils/grid.utils.ts
+++ b/src/utils/grid.utils.ts
@@ -115,11 +115,11 @@ export const getAllCells = (
   gridWidth: number,
   gridHeight: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
 ): Array<Cell> => {
   const cells: Array<Cell> = [];
 
-  const stepSize = gapSize + gridIndicatorSize;
+  const stepSize = gapSize + cellSize;
   let currentIndex = 0;
 
   for (let y = 0; y < gridHeight; y += stepSize) {
@@ -152,14 +152,9 @@ export const findCellsElementOccupies = (
   gridWidth: number,
   gridHeight: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
 ): Array<OccupiedCell> => {
-  const allCells = getAllCells(
-    gridWidth,
-    gridHeight,
-    gapSize,
-    gridIndicatorSize,
-  );
+  const allCells = getAllCells(gridWidth, gridHeight, gapSize, cellSize);
 
   const occupiedCells = allCells
     .filter(cell => cellIsOccupiedByElement(position, size, cell))
@@ -179,7 +174,7 @@ export const findOccupiedCells = (
   gridWidth: number,
   gridHeight: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
 ): Array<OccupiedCell> => {
   const occupiedCells: Array<OccupiedCell> = [];
 
@@ -191,7 +186,7 @@ export const findOccupiedCells = (
         gridWidth,
         gridHeight,
         gapSize,
-        gridIndicatorSize,
+        cellSize,
       ),
     );
   }
@@ -227,7 +222,7 @@ export const positionIsFree = (
   elementSize: Size,
   gridSize: Size,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
   occupiedCells: Array<OccupiedCell>,
 ): boolean => {
   const cellsThisElementWillOccupy = findCellsElementOccupies(
@@ -240,7 +235,7 @@ export const positionIsFree = (
     gridSize.width,
     gridSize.height,
     gapSize,
-    gridIndicatorSize,
+    cellSize,
   );
 
   const cellsOccupiedByOtherElements = occupiedCells.filter(
@@ -258,9 +253,9 @@ export const positionIsFree = (
 export const coordinatePosToPx = (
   coordinate: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
 ): number => {
-  const stepSize = gapSize + gridIndicatorSize;
+  const stepSize = gapSize + cellSize;
 
   return coordinate * stepSize;
 };
@@ -268,9 +263,9 @@ export const coordinatePosToPx = (
 export const coordinateSizeToPx = (
   coordinate: number,
   gapSize: number,
-  gridIndicatorSize: number,
+  cellSize: number,
 ): number => {
-  return coordinate * gridIndicatorSize + (coordinate - 1) * gapSize;
+  return coordinate * cellSize + (coordinate - 1) * gapSize;
 };
 
 export const isDraggingLeft = (


### PR DESCRIPTION
Grid indicators are still grid indicators, however the `cell size` wording is easier to understand imo.