### PR TITLE
use `bahmutov/npm-install` to cache-install npm packages

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,11 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "15.x"
-
       - name: Install Node.js dependencies
         run: npm ci
 
@@ -27,11 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "15.x"
 
       - name: Install Node.js dependencies
         run: npm ci
@@ -46,11 +36,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: "15.x"
 
       - name: Install Node.js dependencies
         run: npm ci
@@ -84,11 +69,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: h5p-editor-topic-map
-
-      - name: Use Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16.x"
 
       - name: Build main project
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Node.js dependencies
-        run: npm ci
+        uses: bahmutov/npm-install@v1
 
       - name: Lint
         run: npm run lint
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Node.js dependencies
-        run: npm ci
+        uses: bahmutov/npm-install@v1
 
       - name: Test
         run: npm run test
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Node.js dependencies
-        run: npm ci
+        uses: bahmutov/npm-install@v1
 
       - name: Build
         run: npm run build
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 0 # 👈 Required to retrieve git history
 
       - name: Install Node.js dependencies
-        run: npm ci
+        uses: bahmutov/npm-install@v1
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1


### PR DESCRIPTION
This change removes about 20 lines from the action yml and cuts off about 30 seconds of total build time.