### PR TITLE
add `workflow_dispatch` to build trigger

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,8 @@
 name: Node.js CI
 
-on: [push]
+on:
+  - push
+  - workflow_dispatch
 
 jobs:
   validate:


### PR DESCRIPTION
This adds a button in the GitHub GUI for triggering workflows manually.
This is great when builds are flaky, or aren't triggered by certain
events.