### PR TITLE
Add indeces to item types

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 14,
+  "patchVersion": 15,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/src/types/ArrowItemType.ts
+++ b/src/types/ArrowItemType.ts
@@ -7,7 +7,7 @@ export type ArrowItemType = CommonItemType & {
    * This index is used for manually sort the items' tab order
    * Arrow item indeces will only be set by the program - not the user
    */
-  index: number | undefined;
+  index?: number;
 
   /** The direction of the arrow's head */
   arrowDirection: ArrowDirection;

--- a/src/types/ArrowItemType.ts
+++ b/src/types/ArrowItemType.ts
@@ -3,6 +3,12 @@ import { ArrowDirection } from "./ArrowDirection";
 import { CommonItemType } from "./CommonItemType";
 
 export type ArrowItemType = CommonItemType & {
+  /**
+   * This index is used for manually sort the items' tab order
+   * Arrow item indeces will only be set by the program - not the user
+   */
+  index: number | undefined;
+
   /** The direction of the arrow's head */
   arrowDirection: ArrowDirection;
 

--- a/src/types/TopicMapItemType.ts
+++ b/src/types/TopicMapItemType.ts
@@ -9,4 +9,10 @@ export type TopicMapItemType = CommonItemType & {
    * and therefore arrows do not have their own customizable labels.
    */
   label: string;
+
+  /*
+   * This index is used for manually sort the items' tab order
+   * Topic map item indeces will be set manually by the user
+   */
+  index: number | undefined;
 };

--- a/src/types/TopicMapItemType.ts
+++ b/src/types/TopicMapItemType.ts
@@ -14,5 +14,5 @@ export type TopicMapItemType = CommonItemType & {
    * This index is used for manually sort the items' tab order
    * Topic map item indeces will be set manually by the user
    */
-  index: number | undefined;
+  index?: number;
 };


### PR DESCRIPTION
They are seperated into their own files, instead of added to the common
type because the documentation is specific for the type.