### PR TITLE
Keep tool active after creating an item

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 27,
+  "patchVersion": 28,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/src/components/Draggable/Draggable.tsx
+++ b/src/components/Draggable/Draggable.tsx
@@ -135,7 +135,8 @@ export const Draggable: FC<DraggableProps> = ({
     (event: React.MouseEvent | React.TouchEvent) => {
       onPointerDown(getPointerPositionFromEvent(event));
       const aToolIsActive = activeTool !== null;
-      if (aToolIsActive) {
+      const createBoxToolIsActive = activeTool === ToolbarButtonType.CreateBox;
+      if (aToolIsActive && !createBoxToolIsActive) {
         return;
       }
 

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -620,7 +620,7 @@ export const Grid: FC<GridProps> = ({
   const editItem = useCallback(
     (id: string) => {
       if (activeTool) {
-        setActiveTool(null)
+        setActiveTool(null);
       }
       setEditedItem(id);
     },

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -213,22 +213,13 @@ export const Grid: FC<GridProps> = ({
 
         updateArrowItems(newItems);
         setArrowItems(newItems);
-        setSelectedItem(newItem.id);
       }
 
       setArrowStartId(null);
       setAhPreviewPosition(null);
       setArrowPreview(null);
     },
-    [
-      activeTool,
-      arrowItems,
-      arrowStartId,
-      items,
-      setActiveTool,
-      setSelectedItem,
-      updateArrowItems,
-    ],
+    [activeTool, arrowItems, arrowStartId, items, updateArrowItems],
   );
 
   const createBoxStart = useCallback(
@@ -246,19 +237,8 @@ export const Grid: FC<GridProps> = ({
       setIsDragging(false);
       setBoxStartIndex(null);
       setCurrentItemsLength(items.length);
-
-      if (items[currentItemsLength]) {
-        setSelectedItem(items[currentItemsLength].id);
-      }
     }
-  }, [
-    activeTool,
-    setCurrentItemsLength,
-    items,
-    setActiveTool,
-    currentItemsLength,
-    setSelectedItem,
-  ]);
+  }, [activeTool, items.length, setCurrentItemsLength]);
 
   const resizeBoxEnd = useCallback(() => {
     setPrevIndex(null);
@@ -639,20 +619,22 @@ export const Grid: FC<GridProps> = ({
 
   const editItem = useCallback(
     (id: string) => {
-      if (!activeTool) {
-        setEditedItem(id);
+      if (activeTool) {
+        setActiveTool(null)
       }
+      setEditedItem(id);
     },
-    [activeTool, setEditedItem],
+    [activeTool, setActiveTool, setEditedItem],
   );
 
   const editArrow = useCallback(
     (id: string) => {
-      if (!activeTool) {
-        setEditedArrow(id);
+      if (activeTool) {
+        setActiveTool(null);
       }
+      setEditedArrow(id);
     },
-    [activeTool, setEditedArrow],
+    [activeTool, setActiveTool, setEditedArrow],
   );
 
   const deleteArrow = useCallback(

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -216,7 +216,6 @@ export const Grid: FC<GridProps> = ({
         setSelectedItem(newItem.id);
       }
 
-      setActiveTool(null);
       setArrowStartId(null);
       setAhPreviewPosition(null);
       setArrowPreview(null);
@@ -247,7 +246,6 @@ export const Grid: FC<GridProps> = ({
       setIsDragging(false);
       setBoxStartIndex(null);
       setCurrentItemsLength(items.length);
-      setActiveTool(null);
 
       if (items[currentItemsLength]) {
         setSelectedItem(items[currentItemsLength].id);


### PR DESCRIPTION
Removes setActiveTool(null) after creating item.

Should maybe avoid setting the created item as selected after creation also? Currently the context menu is overlapping the toolbar, so whenever you create an item at the top it is difficult to deactivate the tool or to select another tool. 