### PR TITLE
change number of columns and rows to odd numbers

### DIFF
--- a/src/components/MapEditorView/MapEditorView.tsx
+++ b/src/components/MapEditorView/MapEditorView.tsx
@@ -34,8 +34,8 @@ export const MapEditorView: React.FC<MapEditorViewProps> = ({
   semantics,
   setParams,
 }) => {
-  const columns = numberOfColumns ?? 30;
-  const rows = numberOfRows ?? 18;
+  const columns = numberOfColumns ?? 31;
+  const rows = numberOfRows ?? 19;
   const defaultGapSize = 4;
 
   const [activeTool, setActiveTool] = useState<ToolbarButtonType | null>(null);


### PR DESCRIPTION
It's much easier to center elements if the grid has an odd number
of columns and rows.