### PR TITLE
Add nullcheck for arrow position

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.TopicMap",
   "majorVersion": 0,
   "minorVersion": 1,
-  "patchVersion": 40,
+  "patchVersion": 41,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/src/components/ClassicArrow/Arrow.tsx
+++ b/src/components/ClassicArrow/Arrow.tsx
@@ -87,29 +87,35 @@ export const ClassicArrow: React.FC<ClassicArrowProps> = ({
   }, [editItem, item.id, updateArrowType]);
 
   const isHorizontal =
-    Math.abs(item.startPosition.x - item.endPosition.x) >
-    Math.abs(item.startPosition.y - item.endPosition.y);
+    item.startPosition != null && item.endPosition != null
+      ? Math.abs(item.startPosition.x - item.endPosition.x) >
+        Math.abs(item.startPosition.y - item.endPosition.y)
+      : true;
 
   const transform = isHorizontal
     ? `translateY(-${gapSize / 2}px)`
     : `translateX(-${gapSize / 2}px)`;
 
-  const xAdjustStart = xAdjustmentStart(item, isHorizontal);
-  const yAdjustStart = yAdjustmentStart(item, isHorizontal);
+  let startPos = { x: 0, y: 0 };
+  let endPos = { x: 0, y: 0 };
 
-  const startPos = {
-    x: (item.startGridPosition.x + xAdjustStart) * (cellSize + gapSize),
-    y: (item.startGridPosition.y + yAdjustStart) * (cellSize + gapSize),
-  };
+  if (item.startGridPosition != null && item.endGridPosition != null) {
+    const xAdjustStart = xAdjustmentStart(item, isHorizontal);
+    const yAdjustStart = yAdjustmentStart(item, isHorizontal);
 
-  const xAdjust = xAdjustmentEnd(item, isHorizontal);
+    const xAdjust = xAdjustmentEnd(item, isHorizontal);
+    const yAdjust = yAdjustmentEnd(item, isHorizontal);
 
-  const yAdjust = yAdjustmentEnd(item, isHorizontal);
+    startPos = {
+      x: (item.startGridPosition.x + xAdjustStart) * (cellSize + gapSize),
+      y: (item.startGridPosition.y + yAdjustStart) * (cellSize + gapSize),
+    };
 
-  const endPos = {
-    x: (item.endGridPosition.x + xAdjust) * (cellSize + gapSize),
-    y: (item.endGridPosition.y + yAdjust) * (cellSize + gapSize),
-  };
+    endPos = {
+      x: (item.endGridPosition.x + xAdjust) * (cellSize + gapSize),
+      y: (item.endGridPosition.y + yAdjust) * (cellSize + gapSize),
+    };
+  }
 
   const pathDef = `M ${startPos.x} ${startPos.y} L ${endPos.x} ${endPos.y}`;
   // Apply shadow around arrow

--- a/src/components/ClassicArrow/Arrow.tsx
+++ b/src/components/ClassicArrow/Arrow.tsx
@@ -96,8 +96,15 @@ export const ClassicArrow: React.FC<ClassicArrowProps> = ({
     ? `translateY(-${gapSize / 2}px)`
     : `translateX(-${gapSize / 2}px)`;
 
-  let startPos = { x: 0, y: 0 };
-  let endPos = { x: 0, y: 0 };
+  // Make old arrows visible in grid, so that they can be deleted
+  let startPos = {
+    x: 0.5 * (cellSize + gapSize),
+    y: 1.5 * (cellSize + gapSize),
+  };
+  let endPos = {
+    x: 6.5 * (cellSize + gapSize),
+    y: 1.5 * (cellSize + gapSize),
+  };
 
   if (item.startGridPosition != null && item.endGridPosition != null) {
     const xAdjustStart = xAdjustmentStart(item, isHorizontal);

--- a/src/components/ClassicArrow/Arrow.tsx
+++ b/src/components/ClassicArrow/Arrow.tsx
@@ -97,6 +97,8 @@ export const ClassicArrow: React.FC<ClassicArrowProps> = ({
     : `translateX(-${gapSize / 2}px)`;
 
   // Make old arrows visible in grid, so that they can be deleted
+  // TODO: Create a new major/minor versjon, delete these arrows in `upgrades.json` and remove code
+  // that suggests that `startPosition`, `endPosition` `startGridPosition` and `endGridPosition` can be undefined
   let startPos = {
     x: 0.5 * (cellSize + gapSize),
     y: 1.5 * (cellSize + gapSize),


### PR DESCRIPTION
For topicMaps that are already created and has arrows, the startGridPosition and endGridPosition is undefined. Need to check if this is null before we can use x and y props