### PR TITLE
fix: amend .h5pignore

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -10,3 +10,5 @@ webpack.config.js
 .storybook
 storybook-static
 docs
+tsconfig.json
+babel.config.js


### PR DESCRIPTION
Currently, .h5pignore doesn't filter out the files `tsconfig.json` and `babel.config.js` when packing.

When merged in, .h5pignore will filter out the files `tsconfig.json` and `babel.config.js` when packing.